### PR TITLE
feat: Add URL routing with dynamic quarter/view segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ pnpm dev
 
 ### Navigation
 
-- Use the **sidebar** to select quarters and navigate between different views
-- Click on **quarter names** (e.g., "2024.Q1") to expand and view options
-- Choose between **Invoices**, **Expenses**, or **Cashflow** views
+- Use the **sidebar** to switch between quarters and views
+- Click on **quarter names** to expand and view available reports
 
 ### Language Toggle
 
@@ -83,16 +82,29 @@ pnpm lint     # Run ESLint
 
 ```
 peris/
-├── app/              # Next.js App Router pages
-├── components/       # React components
-│   ├── ui/          # Reusable UI components (Radix-based)
-│   ├── *-view.tsx   # Main view components
+├── app/
+│   ├── (main)/          # Route group for main application
+│   │   ├── page.tsx     # Welcome page
+│   │   ├── layout.tsx   # Main layout with sidebar
+│   │   └── [quarter]/   # Dynamic quarter segment
+│   │       ├── invoices/page.tsx
+│   │       ├── expenses/page.tsx
+│   │       └── cashflow/
+│   │           ├── page.tsx
+│   │           └── cashflow-client.tsx
+│   ├── layout.tsx       # Root layout with providers
+│   ├── providers.tsx
+│   └── globals.css
+├── components/
+│   ├── ui/              # Reusable UI components (Radix-based)
+│   ├── *-view.tsx       # Main view components
 │   └── ledger-sidebar.tsx
-├── lib/             # Utilities and data
+├── lib/
 │   ├── i18n-context.tsx   # Internationalization
 │   ├── translations.ts    # Language dictionaries
+│   ├── types.ts           # TypeScript type definitions
 │   └── sample-data.ts     # Demo financial data
-└── public/          # Static assets
+└── public/              # Static assets
 ```
 
 ## Deployment

--- a/app/(main)/[quarter]/cashflow/cashflow-client.tsx
+++ b/app/(main)/[quarter]/cashflow/cashflow-client.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { CashflowView } from "@/components/cashflow-view"
+
+interface CashflowClientProps {
+  quarterId: string
+}
+
+export function CashflowClient({ quarterId }: CashflowClientProps) {
+  const router = useRouter()
+
+  function handleNavigateToQuarter(qId: string) {
+    router.push(`/${qId}/cashflow`)
+  }
+
+  return (
+    <CashflowView
+      quarterId={quarterId}
+      onNavigateToQuarter={handleNavigateToQuarter}
+    />
+  )
+}

--- a/app/(main)/[quarter]/cashflow/page.tsx
+++ b/app/(main)/[quarter]/cashflow/page.tsx
@@ -1,0 +1,18 @@
+import { quarterIds } from "@/lib/sample-data"
+import { CashflowClient } from "./cashflow-client"
+
+interface CashflowPageProps {
+  params: Promise<{ quarter: string }>
+}
+
+export async function generateStaticParams() {
+  return quarterIds.map((quarter) => ({
+    quarter,
+  }))
+}
+
+export default async function CashflowPage({ params }: CashflowPageProps) {
+  const { quarter } = await params
+
+  return <CashflowClient quarterId={quarter} />
+}

--- a/app/(main)/[quarter]/expenses/page.tsx
+++ b/app/(main)/[quarter]/expenses/page.tsx
@@ -1,0 +1,18 @@
+import { ExpensesView } from "@/components/expenses-view"
+import { quarterIds } from "@/lib/sample-data"
+
+interface ExpensesPageProps {
+  params: Promise<{ quarter: string }>
+}
+
+export async function generateStaticParams() {
+  return quarterIds.map((quarter) => ({
+    quarter,
+  }))
+}
+
+export default async function ExpensesPage({ params }: ExpensesPageProps) {
+  const { quarter } = await params
+
+  return <ExpensesView quarterId={quarter} />
+}

--- a/app/(main)/[quarter]/invoices/page.tsx
+++ b/app/(main)/[quarter]/invoices/page.tsx
@@ -1,0 +1,18 @@
+import { InvoicesView } from "@/components/invoices-view"
+import { quarterIds } from "@/lib/sample-data"
+
+interface InvoicesPageProps {
+  params: Promise<{ quarter: string }>
+}
+
+export async function generateStaticParams() {
+  return quarterIds.map((quarter) => ({
+    quarter,
+  }))
+}
+
+export default async function InvoicesPage({ params }: InvoicesPageProps) {
+  const { quarter } = await params
+
+  return <InvoicesView quarterId={quarter} />
+}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { WelcomeView } from "@/components/welcome-view"
+import { useRouter } from "next/navigation"
+import type { ViewType } from "@/components/ledger-sidebar"
+
+export default function WelcomePage() {
+  const router = useRouter()
+
+  function handleNavigate(quarter: string, view: ViewType) {
+    router.push(`/${quarter}/${view}`)
+  }
+
+  return <WelcomeView onNavigate={handleNavigate} />
+}

--- a/components/ledger-sidebar.tsx
+++ b/components/ledger-sidebar.tsx
@@ -10,23 +10,24 @@ import {
   BookOpen,
 } from "lucide-react"
 import { useLanguage } from "@/lib/i18n-context"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
 
 export type ViewType = "invoices" | "expenses" | "cashflow"
 
 interface LedgerSidebarProps {
   selectedQuarter: string
   selectedView: ViewType | null
-  onSelectQuarter: (q: string) => void
-  onSelectView: (q: string, v: ViewType) => void
+  onSidebarClose?: () => void
 }
 
 export function LedgerSidebar({
   selectedQuarter,
   selectedView,
-  onSelectQuarter,
-  onSelectView,
+  onSidebarClose,
 }: LedgerSidebarProps) {
   const { language, setLanguage, t } = useLanguage()
+  const router = useRouter()
 
   const viewItems: { key: ViewType; label: string; icon: typeof FileText }[] = [
     { key: "invoices", label: t("sidebar.invoices"), icon: FileText },
@@ -67,7 +68,9 @@ export function LedgerSidebar({
               <li key={qId}>
                 <button
                   type="button"
-                  onClick={() => onSelectQuarter(qId)}
+                  onClick={() => {
+                    router.push(`/${qId}/invoices`)
+                  }}
                   className={cn(
                     "flex w-full items-center justify-between rounded-sm px-3 py-2.5 text-left text-sm transition-colors",
                     isExpanded
@@ -94,23 +97,28 @@ export function LedgerSidebar({
                 {/* Sub-items */}
                 {isExpanded && (
                   <ul className="ml-3 mt-1 flex flex-col gap-0.5 border-l border-sidebar-border pl-3">
-                    {viewItems.map(({ key, label, icon: Icon }) => (
-                      <li key={key}>
-                        <button
-                          type="button"
-                          onClick={() => onSelectView(qId, key)}
-                          className={cn(
-                            "flex w-full items-center gap-2.5 rounded-sm px-3 py-2 text-left text-sm transition-colors",
-                            selectedView === key
-                              ? "bg-sidebar-accent text-sidebar-accent-foreground font-semibold"
-                              : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
-                          )}
-                        >
-                          <Icon className="h-4 w-4" />
-                          {label}
-                        </button>
-                      </li>
-                    ))}
+                    {viewItems.map(({ key, label, icon: Icon }) => {
+                      const href = `/${qId}/${key}`
+                      const isActive =
+                        selectedView === key && selectedQuarter === qId
+                      return (
+                        <li key={key}>
+                          <Link
+                            href={href}
+                            onClick={onSidebarClose}
+                            className={cn(
+                              "flex items-center gap-2.5 rounded-sm px-3 py-2 text-left text-sm transition-colors",
+                              isActive
+                                ? "bg-sidebar-accent text-sidebar-accent-foreground font-semibold"
+                                : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
+                            )}
+                          >
+                            <Icon className="h-4 w-4" />
+                            {label}
+                          </Link>
+                        </li>
+                      )
+                    })}
                   </ul>
                 )}
               </li>


### PR DESCRIPTION
Implement Next.js App Router with URL-based navigation.

Changes:
- Route structure: /[quarter]/invoices, /[quarter]/expenses, /[quarter]/cashflow
- URL-based navigation instead of client-side state
- Sidebar quarter navigation now navigates to quarter/invoices
- Root layout applied to all routes including welcome page
- Support for deep linking and browser back/forward navigation
- Static pre-rendering of all route combinations

Closes #16